### PR TITLE
fix: use posix path methods for Windows compatibility

### DIFF
--- a/src/commands/oas2ro.ts
+++ b/src/commands/oas2ro.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from 'node:fs';
-import path from 'node:path';
+import path from 'node:path/posix';
 import { $RefParser } from '@apidevtools/json-schema-ref-parser';
 import type { Command } from 'commander';
 import type { CommandOptions } from '../cli.ts';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,5 @@
 import { existsSync, lstatSync, readFileSync, readdirSync } from 'node:fs';
-import path from 'node:path';
+import path from 'node:path/posix';
 import { $RefParser } from '@apidevtools/json-schema-ref-parser';
 import type { CommandOptions } from '../cli.ts';
 import { dedupeArray, ensureCleanDirectoryExists } from './util.ts';

--- a/src/lib/roCodeGenerators.ts
+++ b/src/lib/roCodeGenerators.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+import path from 'node:path/posix';
 import type { StdConfig } from './config.ts';
 import { annotationKeys, removeFromParameterKeywords } from './consts.ts';
 import {


### PR DESCRIPTION
Fixes #11 

use `node:path/posix`